### PR TITLE
Fix malli schema definitions + evaluation_handler_test.clj

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
         scicloj/metamorph {:mvn/version "0.2.3"}
         pppmap/pppmap              {:mvn/version "0.2.2"}
         scicloj/tablecloth {:mvn/version "6.023"}
-        metosin/malli {:mvn/version "0.6.2"}}
+        metosin/malli {:mvn/version "0.8.4"}}
 
  :paths ["src" "resources"]
 

--- a/src/scicloj/metamorph/ml.clj
+++ b/src/scicloj/metamorph/ml.clj
@@ -342,8 +342,8 @@
                              [:other-metrices {:optional true} [:sequential [:map
                                                                              [:name keyword?]
                                                                              [:metric-fn fn?]]]]
-                             [:attach-fn-sources {:optional true} [:map [:ns any?
-                                                                         :pipe-fns-clj-file string?]]]]]
+                             [:attach-fn-sources {:optional true} [:map [:ns any?]
+                                                                   [:pipe-fns-clj-file string?]]]]]
       ::evaluation-result
       [:sequential
        [:sequential
@@ -377,9 +377,9 @@
          [:metric-fn fn?]
          [:pipe-decl [:maybe sequential?]]
          [:pipe-fn fn?]
-         [:source-information [:maybe [:map [:classpath [:sequential string?]
-                                             :fn-sources [:map-of :qualified-symbol [:map [:source-form any?
-                                                                                           :source-str string?]]]]]]]]]]}}
+         [:source-information [:maybe [:map [:classpath [:sequential string?]]
+                                       [:fn-sources [:map-of :qualified-symbol [:map [:source-form any?]
+                                                                                [:source-str string?]]]]]]]]]]}}
 
     [:=>
      [:cat
@@ -723,3 +723,4 @@
   (dev/start! {:report (pretty/reporter)})
 
   :ok)
+

--- a/test/scicloj/metamorph/evaluation_handler_test.clj
+++ b/test/scicloj/metamorph/evaluation_handler_test.clj
@@ -18,9 +18,8 @@
         (get-source-information [[:scicloj.metamorph.ml-test/do-xxx]
                                  [:tech.v3.dataset.metamorph/set-inference-target [:species]]
                                  [::tc-pipe/add-column]]
-
                                 (find-ns 'scicloj.metamorph.ml-test)
-                                "/home/carsten/Dropbox/sources/metamorph.ml/test/scicloj/metamorph/ml_test.clj")]
+                                "test/scicloj/metamorph/ml_test.clj")]
 
     (is (=  "(defn do-xxx [col] col)\n"
             (-> source-info :fn-sources (get 'scicloj.metamorph.ml-test/do-xxx) :code-local-source)))))


### PR DESCRIPTION
Hi! I encountered the same issue at #4, so I decided to work up a quick PR to fix it. The changes needed to the `malli` schemas to fix compatibility with the latest version (`v0.8.4`) were relatively small and straightforward - just putting each k/v pair in its own vector. I also bumped the `malli` version and fixed one of the tests by referring to the `ml_test.clj` file in the repo rather than the local path.

I tested this locally with `clojure -Mtest:runner` and the suite passes. Please let me know if you need me to make any revisions!