### PR TITLE
fix: malli/instrument-ns over-instrumenting

### DIFF
--- a/src/scicloj/metamorph/ml/malli.clj
+++ b/src/scicloj/metamorph/ml/malli.clj
@@ -19,7 +19,7 @@
 
 (defn instrument-ns [ns]
   (mi/collect! {:ns ns})
-  (mi/instrument! {:report (pretty/thrower) :scope #{:input}}))
+  (mi/instrument! {:report (pretty/thrower) :scope #{:input} :filters [(mi/-filter-ns ns)]}))
 
 (defn model-options->full-schema [model-options]
   (->


### PR DESCRIPTION
Fix an error where `metamorph.ml.malli/instrument-ns` would instrument all functions registered with malli as opposed to just the provided `ns`.

This was especially apparent in projects that had their own reliance on malli's instrumentation with different options, as any call to `instrument-ns` (including just requiring `metamorph.ml`) would replace the instrumentation that the project had already configured.